### PR TITLE
open pr

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve InstructLab
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Device Info (please complete the following information):**
+ - Hardware Specs: [e.g. Apple M2 Pro Chip, 16 GB Memory, etc.]
+ - OS Version: [e.g. Mac OS 14.4.1, Fedora Linux 40]
+ - Python Version: [output of `python --version`]
+ - InstructLab Version: [output of `ilab --version`]
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+  - ubuntu-gpu

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: E2E test
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_or_branch:
+        description: 'pull request number or branch name'
+        required: true
+        default: 'main'
+
+jobs:
+  e2e:
+    runs-on: ubuntu-gpu
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # https://github.com/actions/checkout/issues/249
+          fetch-depth: 0
+          submodules: 'true'
+
+      - name: Determine if pr_or_branch is a PR number
+        id: check_pr
+        run: |
+          if [[ "${{ github.event.inputs.pr_or_branch }}" =~ ^[0-9]+$ ]]; then
+            echo "is_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch and checkout PR
+        if: steps.check_pr.outputs.is_pr == 'true'
+        run: |
+          git fetch origin pull/${{ github.event.inputs.pr_or_branch }}/head:pr-${{ github.event.inputs.pr_or_branch }}
+          git checkout pr-${{ github.event.inputs.pr_or_branch }}
+
+      - name: Checkout branch
+        if: steps.check_pr.outputs.is_pr == 'false'
+        run: git checkout ${{ github.event.inputs.pr_or_branch }}
+
+      - name: Install Packages
+        run: |
+          sudo apt-get install -y cuda-toolkit git cmake build-essential virtualenv
+          nvidia-smi
+          ls -l /dev/nvidia*
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            **/pyproject.toml
+            **/requirements*.txt
+
+      - name: Cache huggingface
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          # config contains DEFAULT_MODEL
+          key: huggingface-${{ hashFiles('src/instructlab/config.py') }}
+
+      - name: Install ilab
+        run: |
+          export PATH="/home/runner/.local/bin:/usr/local/cuda-12.4/bin:$PATH"
+          python3 -m venv venv
+          . venv/bin/activate
+          sed 's/\[.*\]//' requirements.txt > constraints.txt
+          python3 -m pip cache remove llama_cpp_python
+          CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3 -m pip install --no-binary llama_cpp_python -c constraints.txt llama_cpp_python
+          # needed for --4-bit-quant option to ilab train
+          python3 -m pip install bitsandbytes
+          python3 -m pip install .
+
+      - name: Run e2e test
+        run: |
+          . venv/bin/activate
+          ./scripts/basic-workflow-tests.sh -cm

--- a/.github/workflows/image-cuda.yml
+++ b/.github/workflows/image-cuda.yml
@@ -1,0 +1,109 @@
+name: Test build cuda container image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'containers/cuda/Containerfile'
+      - '.github/workflows/image-cuda.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'containers/cuda/Containerfile'
+      - '.github/workflows/image-cuda.yml'
+
+# Note that the current containerfile builds against a git ref.
+# It is not built against the current source tree. So, we test
+# build the image against `stable` and `main` if the file changes.
+jobs:
+  build_cuda_image_stable:
+    name: Build CUDA image for stable
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          df -h
+          sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
+          sudo rm -rf \
+            /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+            /usr/lib/jvm || true
+          sudo apt install aptitude -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
+          sudo apt-get autoremove -y >/dev/null 2>&1
+          sudo apt-get autoclean -y >/dev/null 2>&1
+          df -h
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for gotbot image
+        id: gobot_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}/instructlab-cuda
+
+      - name: Build and push gobot image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            GIT_TAG=stable
+          push: false
+          tags: ${{ steps.gobot_meta.outputs.tags }}
+          labels: ${{ steps.gobot_meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: containers/cuda/Containerfile
+
+  build_cuda_image_main:
+    name: Build CUDA image for main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          df -h
+          sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
+          sudo rm -rf \
+            /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+            /usr/lib/jvm || true
+          sudo apt install aptitude -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
+          sudo apt-get autoremove -y >/dev/null 2>&1
+          sudo apt-get autoclean -y >/dev/null 2>&1
+          df -h
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for gotbot image
+        id: gobot_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}/instructlab-cuda
+
+      - name: Build and push gobot image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            GIT_TAG=main
+          push: false
+          tags: ${{ steps.gobot_meta.outputs.tags }}
+          labels: ${{ steps.gobot_meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: containers/cuda/Containerfile

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -17,10 +17,7 @@ on:
             - published
 
 permissions:
-    # allow gh release upload
-    contents: write
-    # see https://docs.pypi.org/trusted-publishers/
-    id-token: write
+    contents: read
 
 jobs:
     # Create and verify release artifacts
@@ -47,6 +44,10 @@ jobs:
         # environment: publish-test-pypi
         if: |
             github.repository_owner == 'instructlab' && github.event.action == 'published'
+        permissions:
+            contents: read
+            # see https://docs.pypi.org/trusted-publishers/
+            id-token: write
         runs-on: ubuntu-latest
         needs: build-package
 
@@ -69,6 +70,12 @@ jobs:
         # environment: publish-pypi
         if: |
             github.repository_owner == 'instructlab' && github.event.action == 'published'
+        permissions:
+            # see https://docs.pypi.org/trusted-publishers/
+            id-token: write
+            # allow gh release upload
+            contents: write
+
         runs-on: ubuntu-latest
         needs: build-package
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,11 @@ jobs:
         run: |
           sudo apt-get install -y expect
 
+      - name: Install tools on MacOS
+        if: startsWith(matrix.platform, 'macos')
+        run: |
+          brew install expect coreutils bash
+
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
@@ -82,13 +87,7 @@ jobs:
           python -m pip install tox tox-gh>=1.2
 
       - name: Run unit and functional tests with tox
-        if: startsWith(matrix.platform, 'ubuntu')
         run: tox
-
-      # The functional test shell script does not work on macOS.
-      - name: Run unit tests with tox (macOS)
-        if: startsWith(matrix.platform, 'macos')
-        run: tox -e py-unit
 
   test-workflow-complete:
     needs: ["test"]

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -18,3 +18,4 @@ ignores:
   - "src/instructlab/schema/**"
   - "tests/**"
   - "venv/**"
+  - ".github/ISSUE_TEMPLATE/**"

--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -7,6 +7,8 @@ arge
 arXiv
 backend
 backends
+backport
+backported
 Bhandwaldar
 CLI
 cli
@@ -29,6 +31,7 @@ Finetuning
 GFX
 GGUF
 GiB
+GitHub
 Gmail
 gpu
 hipBLAS

--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -14,6 +14,7 @@ Colab
 compositional
 Conda
 Containerfile
+coreutils
 cpp
 cuBLAS
 CUDA

--- a/CONTRIBUTING/CONTRIBUTING.md
+++ b/CONTRIBUTING/CONTRIBUTING.md
@@ -67,6 +67,8 @@ The following tools are required:
 - [`python`](https://www.python.org) (v3.9+)
 - [`pip`](https://pypi.org/project/pip/) (v23.0+)
 - [`expect`](https://core.tcl-lang.org/expect/index) (for functional tests)
+- [`coreutils`](https://www.gnu.org/software/coreutils/) (for functional tests)
+- [`bash`](https://www.gnu.org/software/bash/) (v5+, for functional tests)
 
 You can setup your dev environment using [`tox`](https://tox.wiki/en/latest/), an environment orchestrator which allows for setting up environments for and invoking builds, unit tests, formatting, linting, etc. Install tox with:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - [❓What is `ilab`](#-what-is-ilab)
 - [📋 Requirements](#-requirements)
 - [✅ Getting started](#-getting-started)
-  - [🧰 Installing`ilab`](#-installing-ilab)
+  - [🧰 Installing `ilab`](#-installing-ilab)
   - [🏗️ Initialize `ilab`](#%EF%B8%8F-initialize-ilab)
   - [📥 Download the model](#-download-the-model)
   - [🍴 Serving the model](#-serving-the-model)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Lint](https://github.com/instructlab/instructlab/actions/workflows/lint.yml/badge.svg?branch=main)
 ![Tests](https://github.com/instructlab/instructlab/actions/workflows/test.yml/badge.svg?branch=main)
 ![Build](https://github.com/instructlab/instructlab/actions/workflows/pypi.yaml/badge.svg?branch=main)
-[![Demo](https://img.shields.io/badge/Demo-v0.13.0-blue)](https://asciinema.org/a/PmRU7IrReep04FY6qpzo2Zclc)
+![Release](https://img.shields.io/github/v/release/instructlab/instructlab)
 ![License](https://img.shields.io/github/license/instructlab/instructlab)
 
 ## 📖 Contents

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The full process is described graphically in the [workflow diagram](./docs/workf
    `taxonomy` seems to not exists or is empty. Should I clone https://github.com/instructlab/taxonomy.git for you? [y/N]: y
    Cloning https://github.com/instructlab/taxonomy.git...
    Generating `config.yaml` in the current directory...
-   Initialization completed successfully, you're ready to start using `lab`. Enjoy!
+   Initialization completed successfully, you're ready to start using `ilab`. Enjoy!
    ```
 
    `ilab` will use the default configuration file unless otherwise specified. You can override this behavior with the `--config` parameter for any `ilab` command.

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ The model can also be downloaded and served locally.
    ilab convert
    ```
 
-3. Serve the newly trained model locally via `ilab serve` command with the `--model`
+3. Serve the newly trained model locally via `ilab serve` command with the `--model-path`
 argument to specify your new model:
 
    ```shell

--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -14,7 +14,9 @@ RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cu
     && export PATH="/usr/local/cuda/bin:$PATH" \
     && export XLA_TARGET=cuda120 \
     && export XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
-RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" CFLAGS="-mno-avx" python3.11 -m pip install -r https://raw.githubusercontent.com/instructlab/instructlab/stable/requirements.txt --force-reinstall --no-cache-dir llama-cpp-python
-RUN python3.11 -m pip install git+https://github.com/instructlab/instructlab.git@stable
-CMD ["/bin/bash"]
 
+ARG GIT_TAG=stable
+RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" CFLAGS="-mno-avx" python3.11 -m pip install -r https://raw.githubusercontent.com/instructlab/instructlab/${GIT_TAG}/requirements.txt --force-reinstall --no-cache-dir llama-cpp-python
+RUN python3.11 -m pip install git+https://github.com/instructlab/instructlab.git@${GIT_TAG}
+
+CMD ["/bin/bash"]

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,14 @@
+# CI for InstructLab
+
+## End-to-end CI Job
+
+This CI job is manually triggered by `instructlab` repo maintainers. It runs as
+much of the `ilab` workflow as it can on the GPU-enabled worker we have
+available through GitHub Actions.
+
+1. Visit the [Actions tab](https://github.com/instructlab/instructlab/actions).
+2. Click on the [E2E test](https://github.com/instructlab/instructlab/actions/workflows/e2e.yml)
+   workflow on the left side of the page.
+3. Click on the `Run workflow` button on the right side of the page.
+4. Enter a branch name or a PR number in the input field.
+5. Click the green `Run workflow` button.

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -1,0 +1,65 @@
+# InstructLab CLI Release Strategy
+
+This document discusses the release strategy and processes for the
+`instructlab` Python package built from the
+<https://github.com/instructlab/instructlab> git repository.
+
+## Versioning Scheme
+
+Releases use a `X.Y.Z` numbering scheme.
+
+X-stream release are for major releases. At this stage in the project a major release has not been cut and we expect each release to be a new Y-stream.
+
+Z-stream releases are meant for critical bug and documentation fixes. Z-stream releases are cut as maintainers see fit.
+
+## Schedule
+
+The project currently operates on a time-based release schedule.
+The goal is to release a new Y-stream every 2-3 weeks though the time span remains flexible based on the discretion of the maintainers team.
+
+The cadence for major releases starting from 1.0 onward will be determined as the project matures.
+
+A schedule will be updated in a markdown file on the <https://github.com/instructlab/instructlab> GitHub repository.
+
+## Release Tracking
+
+Release planning is tracked via [milestones](https://github.com/instructlab/instructlab/milestones) in GitHub. Milestones on GitHub will exist for the next two releases.
+
+PRs and Issues associated with the next two milestones will be prioritized for review and merging into the `main` branch of instructlab.
+
+## Git Branches and Tags
+
+Every `X.Y` release stream gets a new branch.
+
+Each release, `X.Y.Z`, exists as a tag named `vX.Y.Z`.
+
+## Release Branch Maintenance
+
+Maintenance efforts are only on the most recent Y-stream.
+Critical bug fixes are backported to the most recent `X.Y` branch that contains the `stable` tag for a Z-stream release.
+
+## Release Mechanics
+
+Release mechanics are done by a Release Manager identified for that release.
+The Release Manager is a member of the CLI Maintainers team that has agreed to take on these responsibilities.
+The Release Manager can change on a per-release basis.
+The Release Manager for each release is identified in the Description of the Milestone used to plan and track that release on GitHub.
+
+The following are the steps for how Y-stream and Z-stream releases gets cut.
+
+1. Maintainers determine a commit on the main branch that will serve as the basis for the next release.
+    - For a Z-stream release skip this step.
+2. For a Y-Stream release: create a new branch in the format `release-vX.Y`.
+    - For a Z-Stream release skip this step.
+3. For a Z-Stream release: backport all relevant commits from `main` to the `release-X.Y` branch.
+    - For a Y-Stream release skip this step.
+4. Create a new release on GitHub. The following is automated:
+    - Tagging the branch on GitHub
+    - Creating a change log on GitHub
+    - Version number of the Python package is derived from the tag name
+5. Validate the release (manual testing).
+6. Move the `stable` tag to the newest release.
+7. Announce release on the following channels:
+    - InstructLab Slack
+8. Create a milestone on GitHub for the next release without a milestone.
+    - For a Z-Stream release skip this step.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -37,7 +37,7 @@ Pre-requisites:
 1. Setting up and training a LoRA. A LoRA uses Parameter Efficient Fine-tuning (PEFT) methods to fine-tune a model on a small subset of the overall parameters, allowing you to conduct fine-tuning in a fraction of the time, on a fraction of the hardware required. The resultant model should be updated and better handle your queries than the base model.
 1. Inspecting the output model to make sure the LoRA training had the desired effect (i.e. the output has improved).
 
-Once you have finished training and the output looks good, we encourage you go to stage, [Testing the fine-tuned model](../README.md#👩🏽‍🔬-3-testing-the-fine-tuned-model)
+Once you have finished training and the output looks good, we encourage you go to stage, [Testing the fine-tuned model](../README.md#-test-the-newly-trained-model)
 
 ### Kaggle (Unsupported and deprecated)
 

--- a/notebooks/Training_a_LoRA_With_Instruct_Lab.ipynb
+++ b/notebooks/Training_a_LoRA_With_Instruct_Lab.ipynb
@@ -748,7 +748,7 @@
    "source": [
     "# Next Steps\n",
     "\n",
-    "Now that you have trained your LoRA, you must decide, does it look good? If yes, please open a PR **TODO: Link to Contrib docs**, if not that's OK, update your prompts, generate a new synthetic data set and try again.\n",
+    "Now that you have trained your LoRA, you must decide, does it look good? If yes, please [open a PR](https://github.com/instructlab/taxonomy/blob/main/CONTRIBUTING.md), if not that's OK, update your prompts, generate a new synthetic data set and try again.\n",
     "\n",
     "But the fun doesn't stop there.\n",
     "\n",

--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -1,0 +1,233 @@
+#!/bin/sh
+set -euf
+# set -x
+
+# This is a basic workflow test of the ilab CLI.
+#
+# We expect it to be run anywhere `ilab` would run, including the instructlab
+# container images.
+#
+# It represents the tasks a typical user would run through to get familiar with ilab.
+#
+# It is written in shell script because this basic workflow *is* a shell
+# workflow, run through step by step at a shell prompt by a user.
+
+MINIMAL=0
+NUM_INSTRUCTIONS=5
+GENERATE_ARGS=
+TRAIN_ARGS=
+CI=0
+GRANITE=0
+
+export GREP_COLORS='mt=1;33'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+SCRIPTDIR=$(dirname "$0")
+
+step() {
+    echo -e "$BOLD$@$NC"
+}
+
+task() {
+    echo -e "$BOLD------------------------------------------------------$NC"
+    step $@
+}
+
+set_defaults() {
+    if [ "$MINIMAL" -eq 0 ]; then
+        return
+    fi
+
+    NUM_INSTRUCTIONS=1
+    GENERATE_ARGS="--num-cpus $(nproc)"
+    TRAIN_ARGS="--num-epochs 1"
+}
+
+test_smoke() {
+    task Smoke test InstructLab
+    ilab | grep --color 'Usage: ilab'
+}
+
+test_init() {
+    task Initializing ilab
+    [ -f config.yaml ] || printf "taxonomy\ny" | ilab init
+
+    step Checking config.yaml
+    cat config.yaml | grep merlinite
+}
+
+test_download() {
+    task Download the model
+
+    if [ "$GRANITE" -eq 1 ]; then
+        step Downloading the granite model
+        ilab download --repository instructlab/granite-7b-lab-GGUF --filename granite-7b-lab-Q4_K_M.gguf
+    else
+        step Downloading the default model
+        ilab download
+    fi
+}
+
+test_serve() {
+    # Accepts an argument of the model, or default here
+    if [ "$GRANITE" -eq 1 ]; then
+        model="${1:-./models/granite-7b-lab-Q4_K_M.gguf}"
+    else
+        model="${1:-}"
+    fi
+    SERVE_ARGS=""
+    if [ -n "$model" ]; then
+        SERVE_ARGS="--model-path ${model}"
+    fi
+
+    task Serve the model
+    ilab serve ${SERVE_ARGS} &
+
+    ret=1
+    for i in $(seq 1 10); do
+        sleep 5
+    	step $i/10: Waiting for model to start
+        if curl -sS http://localhost:8000/docs > /dev/null; then
+            ret=0
+            break
+        fi
+    done
+
+    return $ret
+}
+
+test_chat() {
+    task Chat with the model
+    CHAT_ARGS=""
+    if [ "$GRANITE" -eq 1 ]; then
+        CHAT_ARGS="-m models/granite-7b-lab-Q4_K_M.gguf"
+    fi
+    printf 'Say "Hello"\n' | ilab chat ${CHAT_ARGS} | grep --color 'Hello'
+}
+
+test_taxonomy() {
+    task Update the taxonomy
+
+    test -d taxonomy || git clone https://github.com/instructlab/taxonomy || true
+
+    step Make new taxonomy
+    mkdir -p taxonomy/knowledge/sports/overview/softball
+
+    step Put new qna file into place
+    cp $SCRIPTDIR/test-data/basic-workflow-fixture-qna.yaml taxonomy/knowledge/sports/overview/softball/qna.yaml
+    head taxonomy/knowledge/sports/overview/softball/qna.yaml | grep --color '1st base'
+
+    step Verification
+    ilab diff
+}
+
+test_generate() {
+    task Generate synthetic data
+    if [ "$GRANITE" -eq 1 ]; then
+        GENERATE_ARGS="--model ./models/granite-7b-lab-Q4_K_M.gguf ${GENERATE_ARGS}"
+    fi
+    ilab generate --num-instructions ${NUM_INSTRUCTIONS} ${GENERATE_ARGS}
+}
+
+test_train() {
+    task Train the model
+
+    # TODO Only cuda for now
+    TRAIN_ARGS="--device=cuda --4-bit-quant"
+    if [ "$GRANITE" -eq 1 ]; then
+        TRAIN_ARGS="--gguf-model-path models/granite-7b-lab-Q4_K_M.gguf ${TRAIN_ARGS}"
+    fi
+
+    ilab train ${TRAIN_ARGS}
+}
+
+test_convert() {
+    task Converting the trained model and serving it
+    ilab convert
+}
+
+test_exec() {
+    # The list of actual tests to run through in workflow order
+    test_smoke
+    test_init
+    test_download
+
+    # See below for cleanup, this runs an ilab serve in the background
+    test_serve
+    PID=$!
+
+    test_chat
+    test_taxonomy
+    test_generate
+
+    # Kill the serve process
+    task Stopping the ilab serve
+    step Kill ilab serve $PID
+    kill $PID
+
+    test_train
+
+    if [ "$CI" -eq 1 ]; then
+        # This is what we expect to work in our CI runner so far
+        return
+    fi
+
+    # The rest is TODO when we can make it work on our CI runner
+
+    # When you run this --
+    #   `ilab convert` is only implemented for macOS with M-series chips for now
+    #test_convert
+
+    # TODO: chat with the new model
+    test_serve /tmp/somemodelthatispretrained.gguf
+    PID=$!
+
+    # TODO: Ask a qestion about softball
+    test_chat
+
+    # Kill the serve process
+    task Stopping the ilab serve
+    step Kill ilab serve $PID
+    kill $PID
+}
+
+usage() {
+    echo "Usage: $0 [-m] [-h]"
+    echo "  -m  Run minimal configuration (run quicker when you have no GPU)"
+    echo "  -c  Run in CI mode (explicitly skip steps we know will fail in linux CI)"
+    echo "  -g  Use the granite model"
+    echo "  -h  Show this help text"
+
+}
+
+# Process command line arguments
+task "Configuring ..."
+while getopts "cmgh" opt; do
+    case $opt in
+        c)
+            CI=1
+            step "Running in CI mode."
+            ;;
+        m)
+            MINIMAL=1
+            step "Running minimal configuration."
+            ;;
+        g)
+            GRANITE=1
+            step "Running with granite model."
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+set_defaults
+test_exec

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -111,15 +111,7 @@ test_ctx_size(){
 
     # Make sure the server has time to open the port
     # if "ilab chat" tests it before its open then it will run its own server without --max-ctx-size 1
-    if ! timeout 30 bash -c '
-        until curl 127.0.0.1:8000|grep "{\"detail\":\"Not Found\"}"; do
-            echo "waiting for server to start"
-            sleep 1
-        done
-    '; then
-        echo "server did not start"
-        exit 1
-    fi
+    wait_for_server
 
     # Should succeed
     ilab chat -qq "Hello"
@@ -305,6 +297,10 @@ test_server_welcome_message(){
     ilab serve &
     PID_SERVE=$!
 
+    wait_for_server
+}
+
+wait_for_server(){
     if ! timeout 30 bash -c '
         until curl 127.0.0.1:8000|grep "{\"message\":\"Hello from InstructLab! Visit us at https://instructlab.ai\"}"; do
             echo "waiting for server to start"

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -293,6 +293,22 @@ test_temp_server_ignore_internal_messages(){
     '
 }
 
+test_server_welcome_message(){
+    # test that the server welcome message is displayed
+    ilab serve &
+    PID_SERVE=$!
+
+    if ! timeout 30 bash -c '
+        until curl 127.0.0.1:8000|grep "{\"message\":\"Hello from InstructLab! Visit us at https://instructlab.ai\"}"; do
+            echo "waiting for server to start"
+            sleep 1
+        done
+    '; then
+        echo "server did not start"
+        exit 1
+    fi
+}
+
 ########
 # MAIN #
 ########
@@ -313,5 +329,7 @@ cleanup
 test_no_chat_logs
 cleanup
 test_temp_server_ignore_internal_messages
+cleanup
+test_server_welcome_message
 
 exit 0

--- a/scripts/test-data/basic-workflow-fixture-qna.yaml
+++ b/scripts/test-data/basic-workflow-fixture-qna.yaml
@@ -1,0 +1,77 @@
+created_by: jjasghar
+domain: sports
+seed_examples:
+- answer: |
+    1st base, 2nd base, 3rd base, and Home
+  question: |
+    What are the 4 bases in softball?
+- answer: |
+    Kitten ball was the first version of modern day softball.
+  question: |
+    What was the first iteration of softball in 1895 invented by Lewis Rober?
+- answer: |
+    12 inches or 30 cms
+  question: |
+    What was the size of the ball in the version of kitten ball created by Lewis Rober?
+- answer: |
+    Thanksgiving Day, 1887 in Chicago, Illinois.
+  question: |
+    When was the first, or earliest known game of softball played?
+- answer: |
+    Softball was originally envisioned for a way for baseball players to maintain their skills during the winter.
+  question: |
+    What was the original envisioning of softball for baseball players?
+- answer: |
+    indoor baseball, kitten ball, diamond ball, mush ball, pumpkinball
+  question: |
+    What was softball also known or named as?
+- answer: |
+    1953
+  question: |
+    When was the first British women's softball leauge established?
+- answer: |
+    7 innings, with a possibilty of 1 or 2 more, with a sudden death round
+  question: |
+    What is the typicial number of innings in a full league softball game?
+- answer: |
+    Home plate.
+  question: |
+    Where does the batter hit from on the field in softball?
+- answer: |
+    43 feet (13.11 m)
+  question: |
+    What is the fastball softball pitching distance for adult (over 16 years) female distance?
+- answer: |
+    43 feet (13.11 m)
+  question: |
+    What is the fastball softball pitching distance for under 16 years but older then 13 female distance?
+- answer: |
+    35 feet (10.67 m)
+  question: |
+    What is the fastball softball pitching distance for under 10 years but older then 8 female distance?
+- answer: |
+    wood, aluminum, or composite materials such as carbon fiber
+  question: |
+    What are the officially approved materials a softball bat can be made out of?
+- answer: |
+    Helmets must be worn by batters and runners.
+  question: |
+    Who on the field must wear a helmet in softball?
+- answer: |
+    Most of the time, the game starts with the umpire saying "play ball"
+  question: |
+    How do you know the softball game has started?
+- answer: |
+    When a throw goes out of the designated play area.
+  question: |
+    What is an overthrow or a "wild throw" in softball?
+- answer: |
+    A player that hits in place of one of the position players but does not play defense.
+  question: |
+    What is the "Designated player" in softball?
+task_description: 'Overview of the sport of softball'
+document:
+  repo: https://github.com/asgharlabs/softball_knowledge
+  commit: aff70ecee013899250f7e28bcbff3fdd6c788a6e
+  patterns:
+  - softball.md

--- a/src/instructlab/generator/generate_data.py
+++ b/src/instructlab/generator/generate_data.py
@@ -499,11 +499,12 @@ def generate_data(
             new_instruction_tokens = scorer._tokenizer.tokenize(
                 instruction_data_entry["instruction"]
             )
-            with mpctx.Pool(num_cpus) as p:
-                rouge_scores = p.map(
+            with mpctx.Pool(num_cpus) as pool:
+                rouge_scores = pool.map(
                     partial(rouge_scorer._score_lcs, new_instruction_tokens),
                     all_instruction_tokens,
                 )
+            pool.join()
             instruction_data_entry["taxonomy_path"] = selected_taxonomy
             rouge_scores = [score.fmeasure for score in rouge_scores]
             # Comment out extra info not currently being used:
@@ -557,6 +558,8 @@ def generate_data(
             for entry in test_data:
                 json.dump(entry, outfile, ensure_ascii=False)
                 outfile.write("\n")
+
+    progress_bar.close()
 
     if total_discarded or total_rouged:
         logger.info(

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1196,14 +1196,27 @@ def test(data_dir, model_dir, adapter_file):
     is_flag=True,
     help="Whether to skip quantization while converting to GGUF.",
 )
+@click.option(
+    "--model-name",
+    help="Name of the model being trained/converted. Informs the naming of the final trained model file",
+    default=None,
+    show_default=True,
+)
 @utils.macos_requirement(echo_func=click.secho, exit_exception=click.exceptions.Exit)
-def convert(model_dir, adapter_file, skip_de_quantize, skip_quantize):
+@click.pass_context
+def convert(ctx, model_dir, adapter_file, skip_de_quantize, skip_quantize, model_name):
     """Converts model to GGUF"""
     # pylint: disable=C0415
     # Local
     from .llamacpp.llamacpp_convert_to_gguf import convert_llama_to_gguf
     from .train.lora_mlx.convert import convert_between_mlx_and_pytorch
     from .train.lora_mlx.fuse import fine_tune
+
+    # compute model name from model-dir if not supplied
+    if model_name is None:
+        mlx_q_suffix = "-mlx-q"
+        model_name = model_dir.split("/")[-1]
+        model_name = model_name.replace(mlx_q_suffix, "")
 
     if adapter_file is None:
         adapter_file = os.path.join(model_dir, "adapters.npz")
@@ -1220,19 +1233,36 @@ def convert(model_dir, adapter_file, skip_de_quantize, skip_quantize):
         de_quantize=not skip_de_quantize,
     )
 
-    model_dir_fused_pt = f"{model_dir_fused}-pt"
+    ctx.obj.logger.info(f"deleting {source_model_dir}...")
+    shutil.rmtree(source_model_dir)
 
+    model_dir_fused_pt = f"{model_name}-trained"
     # this converts MLX to PyTorch
     convert_between_mlx_and_pytorch(
         hf_path=model_dir_fused, mlx_path=model_dir_fused_pt, local=True, to_pt=True
     )
 
-    convert_llama_to_gguf(model=model_dir_fused_pt, pad_vocab=True)
+    ctx.obj.logger.info(f"deleting {model_dir_fused}...")
+    shutil.rmtree(model_dir_fused)
 
-    # quantize 4-bi GGUF (optional)
+    convert_llama_to_gguf(
+        model=model_dir_fused_pt,
+        pad_vocab=True,
+        skip_unknown=True,
+        outfile=f"{model_dir_fused_pt}/{model_name}.gguf",
+    )
+
+    ctx.obj.logger.info(f"deleting safetensors files from {model_dir_fused_pt}...")
+    for file in glob(os.path.join(model_dir_fused_pt, "*.safetensors")):
+        os.remove(file)
+
+    # quantize to 4-bit GGUF (optional)
     if not skip_quantize:
-        gguf_model_dir = f"{model_dir_fused_pt}/ggml-model-f16.gguf"
-        gguf_model_q_dir = f"{model_dir_fused_pt}/ggml-model-Q4_K_M.gguf"
+        gguf_model_dir = f"{model_dir_fused_pt}/{model_name}.gguf"
+        gguf_model_q_dir = f"{model_dir_fused_pt}/{model_name}-Q4_K_M.gguf"
         script = os.path.join(cli_dir, "llamacpp/quantize")
         cmd = f"{script} {gguf_model_dir} {gguf_model_q_dir} Q4_K_M"
         os.system("{}".format(cmd))
+
+    ctx.obj.logger.info(f"deleting {model_dir_fused_pt}/{model_name}.gguf...")
+    os.remove(os.path.join(model_dir_fused_pt, f"{model_name}.gguf"))

--- a/src/instructlab/server.py
+++ b/src/instructlab/server.py
@@ -163,6 +163,12 @@ def server(
         settings.n_threads = threads
     try:
         app = create_app(settings=settings)
+
+        @app.get("/")
+        def read_root():
+            return {
+                "message": "Hello from InstructLab! Visit us at https://instructlab.ai"
+            }
     except ValueError as exc:
         if queue:
             queue.put(exc)

--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -20,13 +20,9 @@ import torch
 
 # Local
 from ..chat.chat import CONTEXTS
-from ..config import DEFAULT_MULTIPROCESSING_START_METHOD
 
 # TODO CPU: Look into using these extensions
 # import intel_extension_for_pytorch as ipex
-
-# 'fork' incompatible with some hardware accelerators
-torch.multiprocessing.set_start_method(DEFAULT_MULTIPROCESSING_START_METHOD)
 
 
 class StoppingCriteriaSub(StoppingCriteria):

--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -114,6 +114,10 @@ def linux_train(
     if device.type == "cuda":
         # estimated by watching nvtop / radeontop during training
         min_vram = 11 if four_bit_quant else 17
+
+        # convert from gibibytes to bytes, torch.cuda.mem_get_info() returns bytes
+        min_vram = min_vram * 1024**3
+
         report_cuda_device(device, min_vram)
 
     print("LINUX_TRAIN.PY: LOADING DATASETS")


### PR DESCRIPTION
- **Document release strategy for Instructlab CLI**
- **release-strategy document revisions after first round of review**
- **Don't fail if multiprocessing is already set to spawn**
- **Set MP start method even earlier**
- **Resolve lint errors**
- **Force spawn MP context, don't use daemonic process**
- **Remove an unused import**
- **feat: run functional test on MacOS**
- **multiprocessing Pool needs pool.join**
- **generate: Explicitly close the progress bar**
- **Ensure we close the queue used with child serve process**
- **Update the --model arg**
- **serve: Attempt to use default multiprocessing method**
- **containers/cuda: Allow specifying git branch to build from**
- **ci: Add a job that does test builds of the cuda image**
- **fix link to "Testing the fine-tuned model"**
- **feat: add a welcome message to our server root**
- **docs: replace 0.13.0 demo badge with current release badge**
- **ci: fix macos job**
- **docs: missing space**
- **Update README.md lab to ilab**
- **updates after second round of review**
- **Add backport to spellchecker**
- **Add Bug and Feature templates for new issues**
- **templates don't need to follow markdown lint rules**
- **Add python version to bug report**
- **Introduce an end-to-end CI job on Linux**
- **e2e: Ensure llama-cpp-python is built with cuda**
- **e2e: Kill `ilab serve` before running `ilab train`**
- **e2e: Add caching for pip and huggingface**
- **Minor edit to wording**
- **docs: Add doc on how to run the end-to-end CI job**
- **clean up intermediate output during convert**
- **paramaterize output file name**
- **replace print statements with ctx logger**
- **rename var, remove unncessary import**
- **run linter**
- **fix four_bit_quant VRAM check for cuda**
- **Use fine-grained permissions for PyPI**
- **notebook: open PR**
